### PR TITLE
Only compare FEType order and family

### DIFF
--- a/src/problems/TensorProblem.C
+++ b/src/problems/TensorProblem.C
@@ -519,9 +519,10 @@ TensorProblem::addTensorBuffer(const std::string & buffer_type,
 
     bool is_nodal;
     const auto & var = aux.getVariable(0, var_name);
-    if (var.feType() == FEType(FIRST, LAGRANGE))
+    const auto & fe_type = var.feType();
+    if (fe_type.order == FIRST && fe_type.family == LAGRANGE)
       is_nodal = true;
-    else if (var.feType() == FEType(CONSTANT, MONOMIAL))
+    else if (fe_type.order == CONSTANT && fe_type.family == MONOMIAL)
       is_nodal = false;
     else
       mooseError("Only first order lagrange and constant monomial variables are supported for "


### PR DESCRIPTION
In idaholab/moose#33248 we are changing the default FEType for Lagrange *and* CONSTANT MONOMIAL to have p_refinement = false. But libMes defaults all FEType constructions to be p_refinement = true. So we have to be careful in our FEType comparisons